### PR TITLE
Add editable layouts across dashboard views

### DIFF
--- a/beast.html
+++ b/beast.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#050608">
-  <meta name="beast-build" content="20260809-37">
-  <meta name="beast-release-tag" content="v0.5.69">
+  <meta name="beast-build" content="20260809-71">
+  <meta name="beast-release-tag" content="v0.6.3">
   <title>HA Smartdash</title>
   <link rel="icon" type="image/svg+xml" href="./favicon.svg">
   <link rel="stylesheet" href="./css/ha-smartdash-tokens.css?v=13">
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="./css/ha-smartdash-cameras.css?v=7">
   <link rel="stylesheet" href="./css/ha-smartdash-security.css?v=8">
   <link rel="stylesheet" href="./css/ha-smartdash-misc.css?v=70">
-  <link rel="stylesheet" href="./css/ha-smartdash-overview.css?v=93">
+  <link rel="stylesheet" href="./css/ha-smartdash-overview.css?v=95">
   <link rel="stylesheet" href="./css/ha-smartdash-weather.css?v=4">
   <link rel="stylesheet" href="./css/ha-smartdash-screenlock.css?v=6">
   <link rel="stylesheet" href="./css/ha-smartdash-responsive.css?v=23">
@@ -29,24 +29,26 @@
   <script src="./js/ha-smartdash-registry.js?v=3"></script>
   <script src="./js/ha-smartdash-local-settings.js?v=6"></script>
   <script src="./js/ha-smartdash-i18n.js?v=3"></script>
-  <script src="./js/ha-smartdash-config.js?v=27"></script>
+  <script src="./js/ha-smartdash-config.js?v=28"></script>
   <script src="./js/ha-smartdash-entity-picker.js?v=1"></script>
-  <script src="./js/ha-smartdash-card-editor.js?v=5"></script>
-  <script src="./js/ha-smartdash-standard-cards.js?v=1"></script>
+  <script src="./js/ha-smartdash-card-editor.js?v=9"></script>
+  <script src="./js/ha-smartdash-page-layout.js?v=1"></script>
+  <script src="./js/ha-smartdash-standard-cards.js?v=5"></script>
+  <script src="./js/ha-smartdash-page-editor.js?v=10"></script>
   <script src="./js/ha-smartdash-screenlock.js?v=10"></script>
-  <script src="./js/ha-smartdash-music.js?v=36"></script>
-  <script src="./js/ha-smartdash-rooms.js?v=17"></script>
-  <script src="./js/ha-smartdash-cameras.js?v=18"></script>
-  <script src="./js/ha-smartdash-security.js?v=13"></script>
-  <script src="./js/ha-smartdash-energy.js?v=23"></script>
-  <script src="./js/ha-smartdash-heating.js?v=7"></script>
-  <script src="./js/ha-smartdash-car.js?v=9"></script>
-  <script src="./js/ha-smartdash-pool.js?v=17"></script>
-  <script src="./js/ha-smartdash-waste.js?v=6"></script>
+  <script src="./js/ha-smartdash-music.js?v=37"></script>
+  <script src="./js/ha-smartdash-rooms.js?v=20"></script>
+  <script src="./js/ha-smartdash-cameras.js?v=19"></script>
+  <script src="./js/ha-smartdash-security.js?v=15"></script>
+  <script src="./js/ha-smartdash-energy.js?v=24"></script>
+  <script src="./js/ha-smartdash-heating.js?v=8"></script>
+  <script src="./js/ha-smartdash-car.js?v=10"></script>
+  <script src="./js/ha-smartdash-pool.js?v=18"></script>
+  <script src="./js/ha-smartdash-waste.js?v=7"></script>
   <script src="./js/ha-smartdash-robots.js?v=23"></script>
   <script src="./js/ha-smartdash-printer.js?v=23"></script>
   <script src="./js/ha-smartdash-overview.js?v=101"></script>
-  <script src="./js/ha-smartdash-weather.js?v=9"></script>
-  <script src="./js/ha-smartdash-app.js?v=81"></script>
+  <script src="./js/ha-smartdash-weather.js?v=10"></script>
+  <script src="./js/ha-smartdash-app.js?v=82"></script>
 </body>
 </html>

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,306 @@
 [
   {
+    "version": "20260809-71",
+    "tag": "v0.6.3",
+    "date": "2026-08-09",
+    "changes": [
+      "Kamera-watchdoggen genindlæser ikke længere hele dashboardet efter gentagne streamfejl.",
+      "Recovery genstarter nu kun kamerarammer og HA-forbindelsen, så aktivt view, scroll og touch-arbejde bevares."
+    ]
+  },
+  {
+    "version": "20260809-70",
+    "tag": "v0.6.2",
+    "date": "2026-08-09",
+    "changes": [
+      "Flyttet layoutknapperne på Sikkerhed, Pool og Bil uden for skjulbare sektioner, så layout altid kan åbnes og gendannes."
+    ]
+  },
+  {
+    "version": "20260809-69",
+    "tag": "v0.6.1",
+    "date": "2026-08-09",
+    "changes": [
+      "Kameraer har nu layoutstyring til featured kamera og kameragrid.",
+      "Valgt kamera, lyd, bevægelsesstatus og streamlogik er bevaret."
+    ]
+  },
+  {
+    "version": "20260809-68",
+    "tag": "v0.6.0",
+    "date": "2026-08-09",
+    "changes": [
+      "Vejr har nu layoutstyring til aktuelt vejr, timeudsigt, ugeudsigt og radar.",
+      "Radarens iframe forbliver monteret ved almindelige vejr-opdateringer."
+    ]
+  },
+  {
+    "version": "20260809-67",
+    "tag": "v0.5.99",
+    "date": "2026-08-09",
+    "changes": [
+      "Musik har nu en layoutdialog til afspiller/højttalere og bibliotek/søgning/album.",
+      "Music Assistant-afspilning, grupper og volumen er bevaret."
+    ]
+  },
+  {
+    "version": "20260809-66",
+    "tag": "v0.5.98",
+    "date": "2026-08-09",
+    "changes": [
+      "Kalender har nu en layoutdialog til affald/afhentning og kommende kalenderaftaler.",
+      "Eksisterende kalendere og affaldssensorer er bevaret."
+    ]
+  },
+  {
+    "version": "20260809-65",
+    "tag": "v0.5.97",
+    "date": "2026-08-09",
+    "changes": [
+      "Views med egne kort bliver nu automatisk lodret scrollbare, når indholdet er højere end skærmen.",
+      "Kamerakort på blandt andet Sikkerhed beskæres ikke længere ved store kortstørrelser."
+    ]
+  },
+  {
+    "version": "20260809-64",
+    "tag": "v0.5.96",
+    "date": "2026-08-09",
+    "changes": [
+      "Bil har nu en layoutdialog til batteri/rækkevidde og status, opladning samt dæktryk.",
+      "Tesla-data og låsestyring er bevaret."
+    ]
+  },
+  {
+    "version": "20260809-63",
+    "tag": "v0.5.95",
+    "date": "2026-08-09",
+    "changes": [
+      "Pool har nu en layoutdialog til status/styring, livekamera samt temperatur- og driftsindsigt.",
+      "Pumpe, automatik, kamera og temperaturhistorik er bevaret."
+    ]
+  },
+  {
+    "version": "20260809-62",
+    "tag": "v0.5.94",
+    "date": "2026-08-09",
+    "changes": [
+      "Varme har nu en layoutdialog til komfortzoner, varmepumper, Dantherm og fjernvarme.",
+      "Eksisterende temperatur- og varmepumpestyring er bevaret."
+    ]
+  },
+  {
+    "version": "20260809-61",
+    "tag": "v0.5.93",
+    "date": "2026-08-09",
+    "changes": [
+      "Energi har nu en layoutdialog til anbefaling, nøgletal, strømprisgraf, forbrugsgraf og forbrug pr. enhed.",
+      "Eksisterende grafer og Overblik/Nu-funktion er bevaret."
+    ]
+  },
+  {
+    "version": "20260809-60",
+    "tag": "v0.5.92",
+    "date": "2026-08-09",
+    "changes": [
+      "Sikkerhed har nu en touch-venlig layoutdialog til at vise eller skjule status, alarmsystemer og indgange.",
+      "Alarm-, låse- og dør/vinduesstyring er uændret."
+    ]
+  },
+  {
+    "version": "20260809-59",
+    "tag": "v0.5.91",
+    "date": "2026-08-09",
+    "changes": [
+      "Rumkort kan nu redigeres direkte: skjul rum og ændr rækkefølgen med touch-venlige op/ned-knapper.",
+      "Rum-popup, lysstyring, termostater og live-status er uændret."
+    ]
+  },
+  {
+    "version": "20260809-58",
+    "tag": "v0.5.90",
+    "date": "2026-08-09",
+    "changes": [
+      "Rettet Rum-viewet efter en syntaksfejl i den nye kortstørrelsesberegning, som forhindrede hele Rum-scriptet i at indlæse."
+    ]
+  },
+  {
+    "version": "20260809-57",
+    "tag": "v0.5.89",
+    "date": "2026-08-09",
+    "changes": [
+      "Fase 2 Sikkerhed-migrering startet: hero, alarmsystemer og indgange kan nu styres via fælles layoutindstillinger uden at ændre alarm- eller låsestyringen."
+    ]
+  },
+  {
+    "version": "20260809-56",
+    "tag": "v0.5.88",
+    "date": "2026-08-09",
+    "changes": [
+      "Fase 2 Rum-migrering startet: rumkort læser nu fælles layoutdata for rækkefølge, skjulte rum og kortstørrelse, mens popup- og live-styring forbliver uændret."
+    ]
+  },
+  {
+    "version": "20260809-55",
+    "tag": "v0.5.87",
+    "date": "2026-08-09",
+    "changes": [
+      "Tilføjet fælles specialkort-kontrakt til fase 2-migreringen, så eksisterende widgets kan få layout, størrelse, synlighed og settings uden at miste deres side-specifikke renderer."
+    ]
+  },
+  {
+    "version": "20260809-54",
+    "tag": "v0.5.86",
+    "date": "2026-08-09",
+    "changes": [
+      "Fase 3-kortbiblioteket udvidet med Graf, Kamera, Medieafspiller og Kalender.",
+      "De nye kort bruger samme entity-søgning, layout, redigering og live-opdatering som de eksisterende kort."
+    ]
+  },
+  {
+    "version": "20260809-53",
+    "tag": "v0.5.85",
+    "date": "2026-08-09",
+    "changes": [
+      "Brugerdefinerede kortnavne bruges nu også direkte i statistik- og touch-kort i stedet for kun at stå som separat label."
+    ]
+  },
+  {
+    "version": "20260809-52",
+    "tag": "v0.5.84",
+    "date": "2026-08-09",
+    "changes": [
+      "Tilføjet Vis/skjul-kort til egne entity-kort, så kort kan deaktiveres uden at blive slettet.",
+      "Skjulte kort bevarer entity, navn, ikon, type og layout og kan aktiveres igen fra indstillinger."
+    ]
+  },
+  {
+    "version": "20260809-51",
+    "tag": "v0.5.83",
+    "date": "2026-08-09",
+    "changes": [
+      "Editorbaren er gjort touch- og kioskvenlig med vandret scroll, faste 48 px touchmål og responsiv placering.",
+      "Editorbaren kan ikke længere skubbe eller ændre højden på det aktive view."
+    ]
+  },
+  {
+    "version": "20260809-50",
+    "tag": "v0.5.82",
+    "date": "2026-08-09",
+    "changes": [
+      "Tilføjet eksport og import af den aktive sides egne kort som JSON.",
+      "Importerede kort får nye id'er, så de ikke kolliderer med eksisterende kort eller overskriver dem utilsigtet."
+    ]
+  },
+  {
+    "version": "20260809-49",
+    "tag": "v0.5.81",
+    "date": "2026-08-09",
+    "changes": [
+      "Tilføjet Ryd egne kort i editoren med bekræftelse; faste specialkort og sidens originale indhold påvirkes ikke.",
+      "Rydning kan fortrydes i samme redigeringssession før layoutet gemmes."
+    ]
+  },
+  {
+    "version": "20260809-48",
+    "tag": "v0.5.80",
+    "date": "2026-08-09",
+    "changes": [
+      "Brugerdefinerede kort kan nu få eget ikon ud over kortnavn, korttype og entity.",
+      "Ikonet bruges i statistik- og entity-visningen og gemmes sammen med kortets layout."
+    ]
+  },
+  {
+    "version": "20260809-47",
+    "tag": "v0.5.79",
+    "date": "2026-08-09",
+    "changes": [
+      "Rettet touch-interaktion i editoren, så Dupliker kort er klikbar sammen med indstillinger, fjern, flyt og skaler.",
+      "Editorens klikblokering tillader nu alle aktive redigerings-handles uden at gøre kortindhold utilsigtet interaktivt."
+    ]
+  },
+  {
+    "version": "20260809-46",
+    "tag": "v0.5.78",
+    "date": "2026-08-09",
+    "changes": [
+      "Tilføjet Dupliker kort i editoren, så ens kort kan bygges hurtigt videre med samme størrelse og layout.",
+      "Duplikerede kort får et nyt id og kan ændres separat uden at påvirke originalen."
+    ]
+  },
+  {
+    "version": "20260809-45",
+    "tag": "v0.5.77",
+    "date": "2026-08-09",
+    "changes": [
+      "Tilføjet central validering og migreringsgrundlag for alle side-layouts, så ugyldige eller gamle kortdata ikke kan ødelægge et helt view.",
+      "Kortdata normaliseres med sikre standarder for id, type, entity og navn før siderne monteres."
+    ]
+  },
+  {
+    "version": "20260809-44",
+    "tag": "v0.5.76",
+    "date": "2026-08-09",
+    "changes": [
+      "Rettet højde-regression i side-editoren: det ekstra custom-kort-grid kan ikke længere arve fuld højde eller dele eksisterende views i to.",
+      "Tilføjet permanent CSS-regressionsværn mod 100%-højde på editorens hjælpe-grid."
+    ]
+  },
+  {
+    "version": "20260809-43",
+    "tag": "v0.5.75",
+    "date": "2026-08-09",
+    "changes": [
+      "Eksisterende brugerdefinerede kort kan nu skifte mellem Entity/sensor, Statistik og Touch-knap direkte fra kortets indstillinger.",
+      "Korttype, kortnavn og entity gemmes samlet, så kort kan bygges videre på uden at blive slettet og oprettet igen."
+    ]
+  },
+  {
+    "version": "20260809-42",
+    "tag": "v0.5.74",
+    "date": "2026-08-09",
+    "changes": [
+      "Udvidet kortbiblioteket med Statistik og touch-venlig Touch-knap til switch, låse og covers.",
+      "Touch-kort bruger Home Assistant-servicekald og opdaterer sig sammen med den valgte entity."
+    ]
+  },
+  {
+    "version": "20260809-41",
+    "tag": "v0.5.73",
+    "date": "2026-08-09",
+    "changes": [
+      "Fælles kort-editor har nu Fortryd, Nulstil og tydeligere gem-flow, så layoutændringer kan afprøves sikkert før de gemmes.",
+      "Ændringer i kort, entity-valg og kortnavne gemmes som redigeringshistorik under den aktive session."
+    ]
+  },
+  {
+    "version": "20260809-40",
+    "tag": "v0.5.72",
+    "date": "2026-08-09",
+    "changes": [
+      "Rettet entity-kort så de bliver vist efter de er gemt, ikke kun mens redigering er åben.",
+      "Tilføjet redigering af kortnavn og valgt entity på de nye kort."
+    ]
+  },
+  {
+    "version": "20260809-39",
+    "tag": "v0.5.71",
+    "date": "2026-08-09",
+    "changes": [
+      "Rettet editoren så et view ikke automatisk får oprettet kort, når redigering åbnes; kort tilføjes nu kun efter brugerens valg.",
+      "Rettet fuldhøjde-fejlen hvor et tomt editor-grid skubbede eksisterende view-indhold ned. Editor-området er nu skjult uden for redigering og fylder kun plads under aktiv redigering."
+    ]
+  },
+  {
+    "version": "20260809-38",
+    "tag": "v0.5.70",
+    "date": "2026-08-09",
+    "changes": [
+      "Tilføjet fælles redigering til de øvrige views: vælg, flyt, skaler og fjern entity-kort direkte på siden.",
+      "Entity-kort viser først relevante forslag for det aktuelle område, men kan altid søge i alle Home Assistant-entiteter til special- og custom-sensorer.",
+      "Editoren genkobler automatisk efter live-opdateringer, så et view ikke mister sine redigeringsmuligheder når data genindlæses."
+    ]
+  },
+  {
     "version": "20260809-37",
     "tag": "v0.5.69",
     "date": "2026-08-09",

--- a/css/ha-smartdash-cameras.css
+++ b/css/ha-smartdash-cameras.css
@@ -146,3 +146,7 @@
   border-radius: var(--radius-full);
   z-index: 1;
 }
+.beast-cameras-panel .is-layout-hidden { display: none !important; }
+.beast-camera-layout-list { display: grid; gap: 10px; margin-bottom: 18px; }
+.beast-camera-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 56px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-camera-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }

--- a/css/ha-smartdash-misc.css
+++ b/css/ha-smartdash-misc.css
@@ -1470,6 +1470,47 @@
    an extra implicit grid row, otherwise height-2 cards occupy only two of
    three rows and leave the bottom third of the full-page view empty. */
 .beast-page-builder-grid > [data-card-editor-anchor] { display: none; }
+.beast-page-editor-host { position: relative; display: contents; }
+.beast-page-editor-scroll-host { overflow-x: hidden !important; overflow-y: auto !important; overscroll-behavior-y: contain; -webkit-overflow-scrolling: touch; }
+.beast-page-editor-scroll-host > :not(.beast-page-editor-host) { flex-shrink: 0; }
+/* Regression guard: this auxiliary editor grid lives inside an existing
+   full-page panel. It must never inherit the overview freeform grid's
+   100%-height/1fr behaviour, otherwise the original view is visually cut in
+   half whenever a custom card is present. */
+.beast-page-entity-grid { display: none; flex: 0 0 auto; width: 100%; height: fit-content !important; max-height: none !important; min-height: 0; margin-top: 18px; overflow: visible !important; grid-auto-rows: minmax(180px, auto) !important; }
+.beast-page-entity-grid.is-editing { display: grid; min-height: 180px; }
+.beast-page-entity-grid.is-freeform { display: grid; min-height: 0; }
+.beast-page-entity-card { min-height: 180px; }
+.beast-page-editor-hint { color: var(--ink-muted); line-height: 1.45; }
+.beast-page-editor-field { display: grid; gap: 7px; margin-bottom: 14px; color: var(--ink-muted); font-size: var(--text-sm); }
+.beast-page-editor-field input { min-height: 50px; padding: 0 14px; border: 1px solid var(--border-strong); border-radius: var(--radius-md); background: var(--surface-solid); color: var(--ink); font: inherit; }
+.beast-page-editor-field select { min-height: 50px; padding: 0 14px; border: 1px solid var(--border-strong); border-radius: var(--radius-md); background: var(--surface-solid); color: var(--ink); font: inherit; }
+.beast-page-editor-check { display: flex; align-items: center; gap: 10px; min-height: 48px; margin-bottom: 14px; color: var(--ink); font-size: var(--text-sm); }
+.beast-page-editor-check input { width: 22px; height: 22px; accent-color: var(--accent); }
+.beast-page-entity-card.is-disabled { opacity: .48; filter: saturate(.4); }
+.beast-page-entity-grid:not(.is-editing) .beast-page-entity-card.is-disabled { display: none; }
+.beast-standard-graph, .beast-standard-media, .beast-standard-calendar { display: grid; gap: 10px; padding: 18px; }
+.beast-standard-graph small, .beast-standard-media small, .beast-standard-calendar small { color: var(--ink-muted); }
+.beast-standard-graph strong, .beast-standard-media strong, .beast-standard-calendar strong { display: block; font-size: var(--text-lg); }
+.beast-standard-media, .beast-standard-calendar { grid-template-columns: auto 1fr; align-items: center; }
+.beast-standard-media > span, .beast-standard-calendar > span { display: grid; place-items: center; width: 48px; height: 48px; border-radius: 14px; background: var(--accent-soft); color: var(--accent); }
+.beast-standard-media em, .beast-standard-calendar em { color: var(--ink-faint); font-size: var(--text-xs); }
+.beast-standard-camera { padding: 10px; }
+.beast-standard-camera-frame { overflow: hidden; aspect-ratio: 16 / 9; display: grid; place-items: center; border-radius: var(--radius-md); background: #05070b; color: var(--ink-muted); }
+.beast-standard-camera-frame img { width: 100%; height: 100%; object-fit: cover; }
+.beast-page-entity-grid .beast-standard-camera-card { min-height: 220px; overflow: visible; }
+.beast-standard-camera strong { display: block; padding: 8px 4px 2px; }
+.beast-page-card-label { position: absolute; top: 12px; right: 16px; color: var(--ink-muted); font-size: var(--text-xs); }
+.beast-ov-card-duplicate { position: absolute; top: 10px; left: 48px; z-index: 22; width: 32px; height: 32px; display: grid; place-items: center; padding: 0; border: 1px solid var(--border-strong); border-radius: 10px; background: var(--surface-solid); color: var(--ink); touch-action: manipulation; }
+.beast-standard-toggle { width: 100%; min-height: 86px; display: flex; align-items: center; gap: 14px; padding: 16px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); color: var(--ink); text-align: left; font: inherit; touch-action: manipulation; }
+.beast-standard-toggle-icon { width: 48px; height: 48px; display: grid; place-items: center; flex: 0 0 48px; border-radius: 14px; background: var(--accent-soft); color: var(--accent); }
+.beast-standard-toggle small, .beast-standard-toggle strong { display: block; }
+.beast-standard-toggle small { color: var(--ink-muted); font-size: var(--text-sm); }
+.beast-standard-toggle strong { margin-top: 3px; font-size: var(--text-lg); }
+.beast-page-entity-modal { width: min(720px, calc(100vw - 36px)); }
+.beast-page-entity-search { width: 100%; min-height: 54px; margin-bottom: 12px; padding: 0 16px; border: 1px solid var(--border-strong); border-radius: var(--radius-md); background: var(--surface-solid); color: var(--ink); font: inherit; }
+.beast-page-entity-select { width: 100%; min-height: 240px; margin-bottom: 14px; padding: 8px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-solid); color: var(--ink); font: inherit; }
+.beast-page-entity-select option { padding: 10px; }
 
 .beast-page-builder-card {
   position: relative;
@@ -2426,3 +2467,32 @@
   font-size: 12.5px;
   line-height: 1.5;
 }
+.beast-energy-panel .is-layout-hidden { display: none !important; }
+.beast-energy-layout-btn { width: 44px; height: 44px; border: 0; background: transparent; color: var(--ink-muted); font-size: 28px; }
+.beast-energy-layout-modal { width: min(620px, calc(100vw - 32px)); }
+.beast-energy-layout-list { display: grid; gap: 10px; margin-bottom: 18px; }
+.beast-energy-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 56px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-energy-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }
+.beast-heating-panel .is-layout-hidden { display: none !important; }
+.beast-heating-layout-btn { width: 44px; height: 44px; border: 0; background: transparent; color: var(--ink-muted); font-size: 28px; }
+.beast-heating-layout-modal { width: min(620px, calc(100vw - 32px)); }
+.beast-heating-layout-list { display: grid; gap: 10px; margin-bottom: 18px; }
+.beast-heating-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 56px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-heating-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }
+.beast-pool-panel .is-layout-hidden { display: none !important; }
+.beast-pool-layout-btn { width: 44px; height: 44px; border: 0; background: transparent; color: var(--ink-muted); font-size: 28px; }
+.beast-pool-layout-modal { width: min(620px, calc(100vw - 32px)); }
+.beast-pool-layout-list { display: grid; gap: 10px; margin-bottom: 18px; }
+.beast-pool-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 56px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-pool-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }
+.beast-car-panel .is-layout-hidden { display: none !important; }
+.beast-car-layout-btn { position: absolute; top: 12px; right: 12px; width: 44px; height: 44px; border: 0; background: transparent; color: var(--ink-muted); font-size: 28px; }
+.beast-car-layout-modal { width: min(620px, calc(100vw - 32px)); }
+.beast-car-layout-list { display: grid; gap: 10px; margin-bottom: 18px; }
+.beast-car-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 56px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-car-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }
+.beast-waste-panel .is-layout-hidden { display: none !important; }
+.beast-calendar-layout-modal { width: min(620px, calc(100vw - 32px)); }
+.beast-calendar-layout-list { display: grid; gap: 10px; margin-bottom: 18px; }
+.beast-calendar-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 56px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-calendar-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }

--- a/css/ha-smartdash-music.css
+++ b/css/ha-smartdash-music.css
@@ -969,3 +969,8 @@
     grid-template-rows: minmax(0, 1fr);
   }
 }
+.beast-music-panel .is-layout-hidden { display: none !important; }
+.beast-music-layout-modal { width: min(620px, calc(100vw - 32px)); }
+.beast-music-layout-list { display: grid; gap: 10px; margin-bottom: 18px; }
+.beast-music-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 56px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-music-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }

--- a/css/ha-smartdash-overview.css
+++ b/css/ha-smartdash-overview.css
@@ -108,11 +108,18 @@
    deliberately explicit Gem/Annullér rather than autosave, since this is a
    shared household touchscreen where an accidental drag must never
    silently persist. */
-.beast-ov-edit-bar { position:fixed; left:50%; bottom:20px; z-index:60; display:flex; align-items:center; gap:16px; padding:12px 14px 12px 20px; transform:translateX(-50%); border:1px solid var(--border-strong); border-radius:999px; background:color-mix(in srgb,var(--surface-2-solid) 96%,transparent); color:var(--ink); font-weight:750; box-shadow:0 18px 46px rgba(0,0,0,.5); backdrop-filter:blur(16px); }
+.beast-ov-edit-bar { position:fixed; left:50%; bottom:20px; z-index:60; max-width:calc(100vw - 28px); display:flex; align-items:center; gap:16px; padding:12px 14px 12px 20px; transform:translateX(-50%); border:1px solid var(--border-strong); border-radius:999px; background:color-mix(in srgb,var(--surface-2-solid) 96%,transparent); color:var(--ink); font-weight:750; box-shadow:0 18px 46px rgba(0,0,0,.5); backdrop-filter:blur(16px); }
 .beast-ov-edit-bar span { display:flex; align-items:center; gap:8px; }
-.beast-ov-edit-bar-actions { display:flex; gap:10px; }
+.beast-ov-edit-bar-actions { display:flex; gap:10px; min-width:max-content; overflow-x:auto; scrollbar-width:none; }
+.beast-ov-edit-bar-actions::-webkit-scrollbar { display:none; }
 .beast-ov-edit-bar-actions button { min-height:40px; padding:0 18px; border-radius:999px; font-weight:750; }
 .beast-ov-edit-bar-actions button[data-ov-edit-cancel] { border:1px solid var(--border-strong); background:transparent; color:var(--ink-muted); }
+.beast-ov-edit-bar-actions button[data-ov-edit-clear] { border:1px solid rgba(255,91,122,.32); background:rgba(255,91,122,.08); color:#ff7b95; }
+@media (max-width: 900px) {
+  .beast-ov-edit-bar { left:12px; right:12px; bottom:12px; max-width:none; transform:none; border-radius:18px; padding:10px 12px; overflow-x:auto; }
+  .beast-ov-edit-bar > span { flex:0 0 auto; }
+  .beast-ov-edit-bar-actions button { min-height:48px; padding-inline:14px; white-space:nowrap; }
+}
 
 .beast-ov-toolbar { position:absolute; top:12px; right:12px; z-index:24; display:flex; gap:8px; }
 .beast-ov-toolbar button { position:relative; width:46px; height:46px; display:grid; place-items:center; border:1px solid var(--border-strong); border-radius:50%; background:color-mix(in srgb,var(--surface-2-solid) 92%,transparent); color:var(--ink-muted); box-shadow:0 10px 28px rgba(0,0,0,.28); backdrop-filter:blur(14px); }
@@ -128,7 +135,7 @@
    guarantee (on top of the JS-level beastOverviewEditing check in
    ha-smartdash-app.js) that nothing inside a card can be tapped by
    accident, including buttons/links this stylesheet doesn't know about. */
-.beast-overview-grid.is-editing .beast-ov-card:not(.beast-ov-card-add) > *:not(.beast-ov-card-drag):not(.beast-ov-card-resize):not(.beast-ov-card-remove):not(.beast-ov-card-configure) { pointer-events: none; }
+.beast-overview-grid.is-editing .beast-ov-card:not(.beast-ov-card-add) > *:not(.beast-ov-card-drag):not(.beast-ov-card-resize):not(.beast-ov-card-remove):not(.beast-ov-card-configure):not(.beast-ov-card-duplicate) { pointer-events: none; }
 .beast-ov-card-drag, .beast-ov-card-resize, .beast-ov-card-remove, .beast-ov-card-configure { position: absolute; z-index: 20; display: grid; place-items: center; touch-action: none; pointer-events: auto; }
 .beast-ov-card-drag { top: 8px; left: 8px; width: 32px; height: 32px; border-radius: 50%; background: rgba(9,12,18,.72); color: #fff; cursor: grab; }
 .beast-ov-card.is-dragging { opacity: .7; box-shadow: 0 22px 60px rgba(0,0,0,.5); z-index: 50; cursor: grabbing; }

--- a/css/ha-smartdash-rooms.css
+++ b/css/ha-smartdash-rooms.css
@@ -30,6 +30,7 @@
   color: var(--ink);
   transition: transform var(--transition-fast), border-color var(--transition-fast);
 }
+.beast-room-card[style*="--room-card-w"] { grid-column: span min(var(--room-card-w), 4); }
 
 .beast-room-card:hover {
   transform: translateY(-2px);
@@ -365,3 +366,10 @@
     grid-auto-rows: minmax(220px, auto);
   }
 }
+.beast-room-layout-modal { width: min(700px, calc(100vw - 32px)); }
+.beast-room-layout-list { display: grid; gap: 8px; margin: 14px 0 18px; }
+.beast-room-layout-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 58px; padding: 8px 12px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-room-layout-row label { display: flex; align-items: center; gap: 10px; min-width: 0; font-size: var(--text-md); }
+.beast-room-layout-row input { width: 24px; height: 24px; accent-color: var(--accent); }
+.beast-room-layout-row button { min-width: 46px; min-height: 46px; border: 1px solid var(--border-strong); border-radius: 12px; background: var(--surface-solid); color: var(--ink); font-size: 20px; }
+.beast-room-layout-row button:disabled { opacity: .35; }

--- a/css/ha-smartdash-security.css
+++ b/css/ha-smartdash-security.css
@@ -261,3 +261,9 @@
   .beast-security-hero { padding: var(--space-5); }
   .beast-security-health > div { min-height: 96px; }
 }
+.beast-security-command .is-layout-hidden { display: none !important; }
+.beast-security-layout-btn { position: absolute; top: 12px; right: 12px; z-index: 5; width: 44px; height: 44px; border: 0; background: transparent; color: var(--ink-muted); font-size: 28px; }
+.beast-security-layout-modal { width: min(620px, calc(100vw - 32px)); }
+.beast-security-layout-list { display: grid; gap: 10px; margin: 16px 0 20px; }
+.beast-security-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 58px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); font-size: var(--text-md); }
+.beast-security-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }

--- a/css/ha-smartdash-weather.css
+++ b/css/ha-smartdash-weather.css
@@ -95,3 +95,7 @@
 .beast-weather-week article > div small { color: var(--ink-faint); }
 .beast-weather-week article > b { grid-column: 1 / -1; display: inline-flex; align-items: center; gap: 4px; color: #55c8ff; font-size: var(--text-xs); }
 :root[data-floating-cards="true"] :is(.beast-weather-current,.beast-weather-hourly,.beast-weather-radar,.beast-weather-week) { background: transparent; border-color: transparent; box-shadow: none; }
+.beast-weather-panel .is-layout-hidden { display: none !important; }
+.beast-weather-layout-list { display: grid; gap: 10px; margin-bottom: 18px; }
+.beast-weather-layout-list label { display: flex; align-items: center; gap: 12px; min-height: 56px; padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); }
+.beast-weather-layout-list input { width: 24px; height: 24px; accent-color: var(--accent); }

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#050608">
-  <meta name="beast-build" content="20260809-37">
-  <meta name="beast-release-tag" content="v0.5.69">
+  <meta name="beast-build" content="20260809-71">
+  <meta name="beast-release-tag" content="v0.6.3">
   <title>HA Smartdash</title>
   <link rel="icon" type="image/svg+xml" href="./favicon.svg">
   <link rel="stylesheet" href="./css/ha-smartdash-tokens.css?v=13">
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="./css/ha-smartdash-cameras.css?v=7">
   <link rel="stylesheet" href="./css/ha-smartdash-security.css?v=8">
   <link rel="stylesheet" href="./css/ha-smartdash-misc.css?v=70">
-  <link rel="stylesheet" href="./css/ha-smartdash-overview.css?v=93">
+  <link rel="stylesheet" href="./css/ha-smartdash-overview.css?v=95">
   <link rel="stylesheet" href="./css/ha-smartdash-weather.css?v=4">
   <link rel="stylesheet" href="./css/ha-smartdash-screenlock.css?v=6">
   <link rel="stylesheet" href="./css/ha-smartdash-responsive.css?v=23">
@@ -29,24 +29,26 @@
   <script src="./js/ha-smartdash-registry.js?v=3"></script>
   <script src="./js/ha-smartdash-local-settings.js?v=6"></script>
   <script src="./js/ha-smartdash-i18n.js?v=3"></script>
-  <script src="./js/ha-smartdash-config.js?v=27"></script>
+  <script src="./js/ha-smartdash-config.js?v=28"></script>
   <script src="./js/ha-smartdash-entity-picker.js?v=1"></script>
-  <script src="./js/ha-smartdash-card-editor.js?v=5"></script>
-  <script src="./js/ha-smartdash-standard-cards.js?v=1"></script>
+  <script src="./js/ha-smartdash-card-editor.js?v=9"></script>
+  <script src="./js/ha-smartdash-page-layout.js?v=1"></script>
+  <script src="./js/ha-smartdash-standard-cards.js?v=5"></script>
+  <script src="./js/ha-smartdash-page-editor.js?v=10"></script>
   <script src="./js/ha-smartdash-screenlock.js?v=10"></script>
-  <script src="./js/ha-smartdash-music.js?v=36"></script>
-  <script src="./js/ha-smartdash-rooms.js?v=17"></script>
-  <script src="./js/ha-smartdash-cameras.js?v=18"></script>
-  <script src="./js/ha-smartdash-security.js?v=13"></script>
-  <script src="./js/ha-smartdash-energy.js?v=23"></script>
-  <script src="./js/ha-smartdash-heating.js?v=7"></script>
-  <script src="./js/ha-smartdash-car.js?v=9"></script>
-  <script src="./js/ha-smartdash-pool.js?v=17"></script>
-  <script src="./js/ha-smartdash-waste.js?v=6"></script>
+  <script src="./js/ha-smartdash-music.js?v=37"></script>
+  <script src="./js/ha-smartdash-rooms.js?v=20"></script>
+  <script src="./js/ha-smartdash-cameras.js?v=19"></script>
+  <script src="./js/ha-smartdash-security.js?v=15"></script>
+  <script src="./js/ha-smartdash-energy.js?v=24"></script>
+  <script src="./js/ha-smartdash-heating.js?v=8"></script>
+  <script src="./js/ha-smartdash-car.js?v=10"></script>
+  <script src="./js/ha-smartdash-pool.js?v=18"></script>
+  <script src="./js/ha-smartdash-waste.js?v=7"></script>
   <script src="./js/ha-smartdash-robots.js?v=23"></script>
   <script src="./js/ha-smartdash-printer.js?v=23"></script>
   <script src="./js/ha-smartdash-overview.js?v=101"></script>
-  <script src="./js/ha-smartdash-weather.js?v=9"></script>
-  <script src="./js/ha-smartdash-app.js?v=81"></script>
+  <script src="./js/ha-smartdash-weather.js?v=10"></script>
+  <script src="./js/ha-smartdash-app.js?v=82"></script>
 </body>
 </html>

--- a/js/ha-smartdash-app.js
+++ b/js/ha-smartdash-app.js
@@ -595,7 +595,13 @@ function runCameraHealthCheck() {
       const lastFullRecovery = Number(sessionStorage.getItem("beast_last_camera_full_recovery") || 0);
       if (reloads >= 3 && now - lastUserActivityAt > 60000 && now - lastFullRecovery > FULL_RECOVERY_COOLDOWN_MS) {
         sessionStorage.setItem("beast_last_camera_full_recovery", String(now));
-        window.location.reload();
+        // Never reload the whole dashboard for a camera failure: that loses
+        // the active view, scroll position and in-progress touch work. The
+        // affected frame has already been restarted above; refresh HA and
+        // ask every visible player to reconnect as the broader recovery.
+        BeastHaSocket.connect?.(true);
+        reconnectVisibleCameraPlayers();
+        BeastCore.log("Kamera-watchdog: bred lokal reconnect uden sidegenindlæsning.");
       }
     } else if (silentFor > CAMERA_RECONNECT_AFTER_MS && now - health.lastReconnectAt > CAMERA_RECONNECT_AFTER_MS) {
       health.lastReconnectAt = now;
@@ -826,6 +832,11 @@ function renderAppShell(root) {
   setupQuickScenarios();
   setupDataQuality();
   BeastCore.mountPanels();
+  // Attach the shared entity-card editor after page panels have rendered.
+  // A short delay also lets panels that start in a loading state finish their
+  // first markup pass before the editor adds its persistent host.
+  window.setTimeout(() => window.BeastPageEditor?.mountAll(), 80);
+  document.addEventListener("beast:navigate", () => window.setTimeout(() => window.BeastPageEditor?.mountAll(), 80));
   BeastHaSocket.connect();
   setupEventFocus();
   window.BeastScreenLock?.init();

--- a/js/ha-smartdash-cameras.js
+++ b/js/ha-smartdash-cameras.js
@@ -162,6 +162,7 @@
     const alreadyShowingFeatured = previousIframe && previousIframe.dataset.slug === featured.slug && featured.streamName;
 
     containerEl.innerHTML = `
+      <button type="button" class="beast-page-edit-trigger" id="beastCamerasLayoutEdit" aria-label="Rediger kameralayout">⋮</button>
       <div class="beast-camera-featured">
         <div class="beast-camera-featured-frame" id="beastCameraFeaturedFrame"></div>
         <span class="beast-camera-featured-label">${escapeHtml(featured.label)}</span>
@@ -170,6 +171,7 @@
       </div>
       <div class="beast-camera-strip" id="beastCameraStrip"></div>
     `;
+    wireCameraLayout();
 
     const frame = document.getElementById("beastCameraFeaturedFrame");
     if (featured.streamName) {
@@ -228,6 +230,23 @@
       });
       strip.appendChild(tile);
     });
+  }
+
+  function wireCameraLayout() {
+    const layout = BeastConfig.get("pageLayouts.cameras.cameraLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    containerEl.querySelector(".beast-camera-featured")?.classList.toggle("is-layout-hidden", hidden.has("featured"));
+    containerEl.querySelector(".beast-camera-strip")?.classList.toggle("is-layout-hidden", hidden.has("grid"));
+    containerEl.querySelector("#beastCamerasLayoutEdit")?.addEventListener("click", () => openCameraLayout(layout));
+  }
+
+  function openCameraLayout(layout) {
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const items = [["featured","Stort kamera"],["grid","Kameragrid"]];
+    const overlay = document.createElement("div"); overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal"><div class="beast-modal-header"><h3>Rediger kameralayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><div class="beast-camera-layout-list">${items.map(([id,label]) => `<label><input type="checkbox" data-camera-section="${id}" ${hidden.has(id)?"":"checked"}><strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-save-camera-layout>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => { if(event.target===overlay||event.target.closest("[data-close]")) return overlay.remove(); if(!event.target.closest("[data-save-camera-layout]")) return; const nextHidden=items.filter(([id])=>!overlay.querySelector(`[data-camera-section="${id}"]`).checked).map(([id])=>id); BeastConfig.set("pageLayouts.cameras.cameraLayout", {...layout,hidden:nextHidden}); overlay.remove(); render(); });
   }
 
   function init(root) {

--- a/js/ha-smartdash-car.js
+++ b/js/ha-smartdash-car.js
@@ -95,7 +95,7 @@
       ? new Date(finishState.state).toLocaleTimeString("da-DK", { hour: "2-digit", minute: "2-digit" }) : null;
 
     containerEl.innerHTML = `
-      <div class="beast-car-top">
+      <button type="button" class="beast-page-edit-trigger" id="beastCarLayoutEdit" aria-label="Rediger billayout">⋮</button><div class="beast-car-top">
         <div class="beast-car-battery">
           <div class="beast-car-liquid-battery${charging ? " is-charging" : ""}" style="--battery-level:${batteryLevel}%; --battery-hue:${Math.round(batteryLevel * 1.2)}" role="img" aria-label="Batteri ${batteryPct} procent">
             <i class="beast-car-battery-terminal"></i>
@@ -139,9 +139,32 @@
         ${buildTpms()}
       </div>
     `;
+    wireCarLayout();
 
     document.getElementById("beastCarLockBtn")?.addEventListener("click", () => {
       callService("lock", locked ? "unlock" : "lock", IDS.lock).then(() => window.setTimeout(render, 400));
+    });
+  }
+
+  function wireCarLayout() {
+    const layout = BeastConfig.get("pageLayouts.car.carLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    containerEl.querySelector(".beast-car-top")?.classList.toggle("is-layout-hidden", hidden.has("battery"));
+    containerEl.querySelector(".beast-stat-grid")?.classList.toggle("is-layout-hidden", hidden.has("details"));
+    containerEl.querySelector("#beastCarLayoutEdit")?.addEventListener("click", () => openCarLayout(layout));
+  }
+
+  function openCarLayout(layout) {
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const items = [["battery", "Batteri og rækkevidde"], ["details", "Status, opladning og dæktryk"]];
+    const overlay = document.createElement("div"); overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal beast-car-layout-modal"><div class="beast-modal-header"><h3>Rediger billayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><div class="beast-car-layout-list">${items.map(([id,label]) => `<label><input type="checkbox" data-car-section="${id}" ${hidden.has(id) ? "" : "checked"}><strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-save-car-layout>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (!event.target.closest("[data-save-car-layout]")) return;
+      const nextHidden = items.filter(([id]) => !overlay.querySelector(`[data-car-section="${id}"]`).checked).map(([id]) => id);
+      BeastConfig.set("pageLayouts.car.carLayout", { ...layout, hidden: nextHidden }); overlay.remove(); render();
     });
   }
 

--- a/js/ha-smartdash-card-editor.js
+++ b/js/ha-smartdash-card-editor.js
@@ -61,6 +61,8 @@ window.BeastCardEditor = (function () {
 
     let editing = false;
     let draftCards = null;
+    let originalCards = null;
+    let history = [];
 
     function renderCardsDom(cards) {
       if (!zoneEl) return;
@@ -76,6 +78,10 @@ window.BeastCardEditor = (function () {
         renderAddCardTile(anchor);
         applyEditModeChrome();
       }
+    }
+
+    function rememberDraft() {
+      if (draftCards) history.push(JSON.parse(JSON.stringify(draftCards)));
     }
 
     // "+ Tilføj kort" -- not a real card, never part of draftCards, always
@@ -104,6 +110,7 @@ window.BeastCardEditor = (function () {
         card.querySelector(".beast-ov-card-resize")?.remove();
         card.querySelector(".beast-ov-card-remove")?.remove();
         card.querySelector(".beast-ov-card-configure")?.remove();
+        card.querySelector(".beast-ov-card-duplicate")?.remove();
         const drag = document.createElement("span");
         drag.className = "beast-ov-card-drag";
         drag.setAttribute("aria-hidden", "true");
@@ -134,16 +141,35 @@ window.BeastCardEditor = (function () {
               if (!updatedCard) return;
               const index = draftCards.findIndex((item) => item.id === current.id);
               if (index < 0) return;
+              rememberDraft();
               draftCards[index] = { ...draftCards[index], ...updatedCard, id: current.id };
               renderCardsDom(draftCards);
             });
           });
         }
+        const duplicate = document.createElement("button");
+        duplicate.type = "button";
+        duplicate.className = "beast-ov-card-duplicate";
+        duplicate.setAttribute("aria-label", "Dupliker kort");
+        duplicate.innerHTML = BeastCore.icon("plus", { size: 15 });
+        card.appendChild(duplicate);
+        duplicate.addEventListener("click", (event) => {
+          event.stopPropagation();
+          rememberDraft();
+          const source = draftCards.find((item) => item.id === card.dataset.builderCard);
+          if (!source) return;
+          const clone = JSON.parse(JSON.stringify(source));
+          clone.id = `card_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+          clone.label = clone.label ? `${clone.label} kopi` : "";
+          draftCards.push(clone);
+          renderCardsDom(draftCards);
+        });
         wireCardDrag(card, drag);
         wireCardResize(card, resize);
         remove.addEventListener("click", (event) => {
           event.stopPropagation();
           const id = card.dataset.builderCard;
+          rememberDraft();
           draftCards = draftCards.filter((c) => c.id !== id);
           renderCardsDom(draftCards);
         });
@@ -277,6 +303,7 @@ window.BeastCardEditor = (function () {
         if (typeButton) {
           const type = typeButton.dataset.addCardType;
           if (!entityPickerTypes.includes(type)) {
+            rememberDraft();
             draftCards.push(newCard(type));
             close();
             renderCardsDom(draftCards);
@@ -301,6 +328,7 @@ window.BeastCardEditor = (function () {
           const select = overlay.querySelector(".beast-ov-add-card-select");
           const entity = select?.value;
           if (!entity) return;
+          rememberDraft();
           draftCards.push(newCard(overlay.dataset.pendingEntityType || "custom", entity));
           close();
           renderCardsDom(draftCards);
@@ -313,10 +341,62 @@ window.BeastCardEditor = (function () {
       const bar = document.createElement("div");
       bar.id = "beastCardEditorBar";
       bar.className = "beast-ov-edit-bar";
-      bar.innerHTML = `<span>${BeastCore.icon("grid", { size: 16 })}${editLabel}</span><div class="beast-ov-edit-bar-actions"><button type="button" data-ov-edit-cancel>Annullér</button><button type="button" class="beast-btn beast-btn-primary" data-ov-edit-save>Gem</button></div>`;
+      bar.innerHTML = `<span>${BeastCore.icon("grid", { size: 16 })}${editLabel}</span><div class="beast-ov-edit-bar-actions"><button type="button" data-ov-edit-undo ${history.length ? "" : "disabled"}>Fortryd</button><button type="button" data-ov-edit-reset>Nulstil</button><button type="button" data-ov-edit-clear>Ryd egne kort</button><button type="button" data-ov-edit-export>Eksportér</button><button type="button" data-ov-edit-import>Importér</button><button type="button" data-ov-edit-cancel>Annullér</button><button type="button" class="beast-btn beast-btn-primary" data-ov-edit-save>Gem</button></div>`;
       document.body.appendChild(bar);
       bar.querySelector("[data-ov-edit-cancel]").addEventListener("click", () => exit(false));
       bar.querySelector("[data-ov-edit-save]").addEventListener("click", () => exit(true));
+      bar.querySelector("[data-ov-edit-undo]").addEventListener("click", () => {
+        const previous = history.pop();
+        if (!previous) return;
+        draftCards = previous;
+        renderCardsDom(draftCards);
+        renderEditBar();
+      });
+      bar.querySelector("[data-ov-edit-reset]").addEventListener("click", () => {
+        if (!window.confirm("Nulstil kortene på denne side til layoutet før redigering?")) return;
+        history.push(JSON.parse(JSON.stringify(draftCards || [])));
+        draftCards = JSON.parse(JSON.stringify(originalCards || []));
+        renderCardsDom(draftCards);
+        renderEditBar();
+      });
+      bar.querySelector("[data-ov-edit-clear]").addEventListener("click", () => {
+        if (!draftCards?.length || !window.confirm("Fjern alle egne kort fra denne side?")) return;
+        rememberDraft();
+        draftCards = [];
+        renderCardsDom(draftCards);
+        renderEditBar();
+      });
+      bar.querySelector("[data-ov-edit-export]").addEventListener("click", async () => {
+        const payload = JSON.stringify({ smartdash: "card-layout", version: 1, cards: draftCards || [] }, null, 2);
+        try {
+          await navigator.clipboard.writeText(payload);
+          bar.querySelector("[data-ov-edit-export]").textContent = "Kopieret";
+          window.setTimeout(() => renderEditBar(), 1000);
+        } catch (error) {
+          window.prompt("Kopiér layout-JSON:", payload);
+        }
+      });
+      bar.querySelector("[data-ov-edit-import]").addEventListener("click", () => {
+        const input = document.createElement("input");
+        input.type = "file"; input.accept = "application/json,.json";
+        input.addEventListener("change", () => {
+          const file = input.files?.[0]; if (!file) return;
+          const reader = new FileReader();
+          reader.onload = () => {
+            try {
+              const parsed = JSON.parse(String(reader.result || ""));
+              const cards = Array.isArray(parsed) ? parsed : parsed.cards;
+              if (!Array.isArray(cards)) throw new Error("Ugyldigt layout");
+              if (!cards.every((card) => card && typeof card === "object" && typeof card.id === "string")) throw new Error("Ugyldigt kortformat");
+              rememberDraft();
+              draftCards = cards.map((card) => ({ ...card, id: `card_${Date.now()}_${Math.random().toString(36).slice(2, 7)}` }));
+              renderCardsDom(draftCards); renderEditBar();
+            } catch (error) { window.alert("Layoutet kunne ikke importeres. Kontrollér JSON-filen."); }
+          };
+          reader.readAsText(file);
+        });
+        input.click();
+      });
     }
 
     function enter() {
@@ -325,6 +405,8 @@ window.BeastCardEditor = (function () {
       window.beastCardEditorActive = true;
       const existing = BeastConfig.get(configPath) || [];
       draftCards = existing.length ? JSON.parse(JSON.stringify(existing)) : seedCards();
+      originalCards = JSON.parse(JSON.stringify(draftCards));
+      history = [];
       renderEditBar();
       renderCardsDom(draftCards);
     }
@@ -335,6 +417,8 @@ window.BeastCardEditor = (function () {
       editing = false;
       window.beastCardEditorActive = false;
       draftCards = null;
+      originalCards = null;
+      history = [];
       document.getElementById("beastCardEditorBar")?.remove();
       if (!nextCards.length && renderEmptyState) {
         renderEmptyState();

--- a/js/ha-smartdash-config.js
+++ b/js/ha-smartdash-config.js
@@ -96,7 +96,10 @@ const BeastConfig = (() => {
     overviewCards: [],
     pageLayouts: {
       robots: { cards: [] },
-      printer: { cards: [] }
+      printer: { cards: [] },
+      rooms: { cards: [] }, cameras: { cards: [] }, security: { cards: [] }, music: { cards: [] },
+      energy: { cards: [] }, heating: { cards: [] }, car: { cards: [] }, pool: { cards: [] },
+      waste: { cards: [] }, weather: { cards: [] }
     },
     // The two small tiles under the clock/calendar card -- each is one of
     // "car"/"pool"/"robots"/"printer" (same set as the top-level generic
@@ -189,6 +192,27 @@ const BeastConfig = (() => {
     return config;
   }
 
+  // Layouts are user data, so keep malformed/old entries from breaking a
+  // whole page. This also gives future card migrations one stable place to
+  // evolve from instead of scattering compatibility checks across views.
+  function normalizePageLayouts(config) {
+    if (!isPlainObject(config.pageLayouts)) config.pageLayouts = {};
+    Object.keys(DEFAULTS.pageLayouts).forEach((pageId) => {
+      const layout = config.pageLayouts[pageId];
+      if (!isPlainObject(layout)) config.pageLayouts[pageId] = { cards: [] };
+      if (!Array.isArray(config.pageLayouts[pageId].cards)) config.pageLayouts[pageId].cards = [];
+      config.pageLayouts[pageId].cards = config.pageLayouts[pageId].cards
+        .filter((card) => isPlainObject(card) && typeof card.id === "string" && card.id)
+        .map((card) => ({
+          ...card,
+          type: typeof card.type === "string" ? card.type : "custom",
+          entity: typeof card.entity === "string" ? card.entity : null,
+          label: typeof card.label === "string" ? card.label : ""
+        }));
+    });
+    return config;
+  }
+
   // Called once at boot, before any panel mounts, so every later get() call
   // is a plain synchronous object read — panels never need to know config
   // is backed by a network request.
@@ -201,7 +225,7 @@ const BeastConfig = (() => {
         return readLocalFallback();
       })
       .then((remote) => {
-        cache = deepMerge(DEFAULTS, remote || {});
+        cache = normalizePageLayouts(deepMerge(DEFAULTS, remote || {}));
         writeLocalFallback(cache);
         return cache;
       });
@@ -212,7 +236,7 @@ const BeastConfig = (() => {
   // init() resolves — shouldn't happen since the boot sequence awaits it,
   // but a stale local cache beats throwing.
   function ensureLoaded() {
-    if (!cache) cache = deepMerge(DEFAULTS, readLocalFallback());
+    if (!cache) cache = normalizePageLayouts(deepMerge(DEFAULTS, readLocalFallback()));
     return cache;
   }
 

--- a/js/ha-smartdash-energy.js
+++ b/js/ha-smartdash-energy.js
@@ -246,7 +246,31 @@
         <button type="button" data-energy-view="overview" class="${energyView === "overview" ? "is-active" : ""}">Overblik</button>
         <button type="button" data-energy-view="now" class="${energyView === "now" ? "is-active" : ""}">Nu</button>
       </div>
+      <button type="button" class="beast-energy-layout-btn" data-energy-layout aria-label="Rediger energilayout">⋮</button>
     </div>`;
+  }
+
+  function wireEnergyLayout() {
+    const layout = BeastConfig.get("pageLayouts.energy.energyLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const map = { recommendation: ".beast-energy-recommendation", summary: ".beast-stat-grid, .beast-energy-now-summary", price: ".beast-energy-chart-price", usage: ".beast-energy-chart-usage", devices: ".beast-energy-now-groups" };
+    Object.entries(map).forEach(([id, selector]) => containerEl.querySelectorAll(selector).forEach((el) => el.classList.toggle("is-layout-hidden", hidden.has(id))));
+    containerEl.querySelector("[data-energy-layout]")?.addEventListener("click", () => openEnergyLayout(layout));
+  }
+
+  function openEnergyLayout(layout) {
+    document.getElementById("beastEnergyLayoutEditor")?.remove();
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const items = [["recommendation", "Anbefaling"], ["summary", "Nøgletal"], ["price", "Strømprisgraf"], ["usage", "Forbrugsgraf"], ["devices", "Forbrug pr. enhed"]];
+    const overlay = document.createElement("div"); overlay.id = "beastEnergyLayoutEditor"; overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal beast-energy-layout-modal"><div class="beast-modal-header"><h3>Rediger energilayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><div class="beast-energy-layout-list">${items.map(([id,label]) => `<label><input type="checkbox" data-energy-section="${id}" ${hidden.has(id) ? "" : "checked"}><strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-save-energy-layout>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (!event.target.closest("[data-save-energy-layout]")) return;
+      const nextHidden = items.filter(([id]) => !overlay.querySelector(`[data-energy-section="${id}"]`).checked).map(([id]) => id);
+      BeastConfig.set("pageLayouts.energy.energyLayout", { ...layout, hidden: nextHidden }); overlay.remove(); render();
+    });
   }
 
   function renderNowView() {
@@ -342,6 +366,7 @@
     if (energyView === "now") {
       if (!containerEl.querySelector(".beast-energy-now-groups")) {
         containerEl.innerHTML = renderNowView();
+        wireEnergyLayout();
         containerEl.querySelectorAll("[data-energy-view]").forEach((button) => button.addEventListener("click", () => {
           energyView = button.dataset.energyView;
           render();
@@ -437,6 +462,7 @@
         ${cachedHistoryPoints.length ? buildDetailedUsageChart(cachedHistoryPoints) : '<p class="beast-music-empty">Henter historik…</p>'}
       </div>
     `;
+    wireEnergyLayout();
 
     containerEl.querySelectorAll("[data-view]").forEach((btn) => {
       btn.addEventListener("click", () => {

--- a/js/ha-smartdash-heating.js
+++ b/js/ha-smartdash-heating.js
@@ -134,6 +134,7 @@
           <button type="button" class="beast-heating-auto${automationOn ? " is-on" : ""}" id="beastHeatingAutoBtn">
             ${BeastCore.icon("bolt", { size: 20 })}<span><small>Automatisk styring</small><strong>${automationOn ? "Aktiv" : "Slået fra"}</strong></span>
           </button>
+          <button type="button" class="beast-heating-layout-btn" id="beastHeatingLayoutEdit" aria-label="Rediger varmelayout">⋮</button>
         </div>
         <div class="beast-heating-room-grid">${ROOMS.map(buildRoomCard).join("")}</div>
         <div class="beast-heating-pumps-head"><span>Varmepumper</span><small>Fuld direkte styring</small></div>
@@ -164,6 +165,7 @@
         </section>
       </aside>
     `;
+    wireHeatingLayout();
 
     containerEl.querySelectorAll("[data-action='heat-up'], [data-action='heat-down']").forEach((btn) => {
       btn.addEventListener("click", () => {
@@ -195,6 +197,29 @@
 
     document.getElementById("beastHeatingAutoBtn")?.addEventListener("click", () => {
       callService("input_boolean", automationOn ? "turn_off" : "turn_on", AUTOMATION_ID).then(() => window.setTimeout(render, 400));
+    });
+  }
+
+  function wireHeatingLayout() {
+    const layout = BeastConfig.get("pageLayouts.heating.heatingLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const selectors = { rooms: ".beast-heating-room-grid", pumps: ".beast-heating-pumps-head, .beast-heatpump-grid", dantherm: ".beast-dantherm-card", district: ".beast-district-compact" };
+    Object.entries(selectors).forEach(([id, selector]) => containerEl.querySelectorAll(selector).forEach((el) => el.classList.toggle("is-layout-hidden", hidden.has(id))));
+    containerEl.querySelector("#beastHeatingLayoutEdit")?.addEventListener("click", () => openHeatingLayout(layout));
+  }
+
+  function openHeatingLayout(layout) {
+    document.getElementById("beastHeatingLayoutEditor")?.remove();
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const items = [["rooms", "Komfortzoner"], ["pumps", "Varmepumper"], ["dantherm", "Dantherm ventilation"], ["district", "Fjernvarme"]];
+    const overlay = document.createElement("div"); overlay.id = "beastHeatingLayoutEditor"; overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal beast-heating-layout-modal"><div class="beast-modal-header"><h3>Rediger varmelayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><div class="beast-heating-layout-list">${items.map(([id,label]) => `<label><input type="checkbox" data-heating-section="${id}" ${hidden.has(id) ? "" : "checked"}><strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-save-heating-layout>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (!event.target.closest("[data-save-heating-layout]")) return;
+      const nextHidden = items.filter(([id]) => !overlay.querySelector(`[data-heating-section="${id}"]`).checked).map(([id]) => id);
+      BeastConfig.set("pageLayouts.heating.heatingLayout", { ...layout, hidden: nextHidden }); overlay.remove(); render();
     });
   }
 

--- a/js/ha-smartdash-music.js
+++ b/js/ha-smartdash-music.js
@@ -337,7 +337,7 @@
     const visibleGroupCount = stereoGroupInfo(activePlayer.entity_id)?.speakers || new Set([...nativeGroupIds, ...linkedPlayerIds(groupLeaderId)]).size;
 
     containerEl.innerHTML = `
-      <div class="beast-music-dashboard">
+      <button type="button" class="beast-page-edit-trigger" id="beastMusicLayoutEdit" aria-label="Rediger musiklayout">⋮</button><div class="beast-music-dashboard">
         <aside class="beast-music-control">
           <header class="beast-music-section-head">
             <button type="button" class="beast-speaker-toggle" id="beastSpeakerToggle" aria-expanded="${speakerPanelOpen}">
@@ -397,6 +397,7 @@
         </main>
       </div>
     `;
+    wireMusicLayout();
 
     renderPlayerChips(players, activePlayer);
     renderGroupVolume(players, activePlayer);
@@ -413,6 +414,28 @@
     } else {
       loadTabsAndGrid(activePlayer);
     }
+  }
+
+  function wireMusicLayout() {
+    const layout = BeastConfig.get("pageLayouts.music.musicLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    containerEl.querySelector(".beast-music-control")?.classList.toggle("is-layout-hidden", hidden.has("player"));
+    containerEl.querySelector(".beast-music-library")?.classList.toggle("is-layout-hidden", hidden.has("library"));
+    containerEl.querySelector("#beastMusicLayoutEdit")?.addEventListener("click", () => openMusicLayout(layout));
+  }
+
+  function openMusicLayout(layout) {
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const items = [["player", "Afspiller og højttalere"], ["library", "Bibliotek, søgning og album"]];
+    const overlay = document.createElement("div"); overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal beast-music-layout-modal"><div class="beast-modal-header"><h3>Rediger musiklayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><div class="beast-music-layout-list">${items.map(([id,label]) => `<label><input type="checkbox" data-music-section="${id}" ${hidden.has(id) ? "" : "checked"}><strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-save-music-layout>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (!event.target.closest("[data-save-music-layout]")) return;
+      const nextHidden = items.filter(([id]) => !overlay.querySelector(`[data-music-section="${id}"]`).checked).map(([id]) => id);
+      BeastConfig.set("pageLayouts.music.musicLayout", { ...layout, hidden: nextHidden }); overlay.remove(); render();
+    });
   }
 
   function wireSearchInput(activePlayer) {

--- a/js/ha-smartdash-page-editor.js
+++ b/js/ha-smartdash-page-editor.js
@@ -1,0 +1,101 @@
+// Shared editor for full-page views that do not need a page-specific card
+// renderer. It keeps the existing specialised view intact and adds a
+// configurable layer of entity cards below it. The same editor is used by
+// every page, so drag/resize/search/save behaviour stays consistent.
+window.BeastPageEditor = (() => {
+  const EXCLUDED = new Set(["overview", "robots", "printer", "settings"]);
+  const LABELS = {
+    rooms: "Rum", cameras: "Kameraer", security: "Sikkerhed", music: "Musik",
+    energy: "Energi", heating: "Varme", car: "Bil", pool: "Pool",
+    waste: "Kalender", weather: "Vejr"
+  };
+  const DOMAIN_HINTS = {
+    rooms: ["light", "climate", "sensor", "binary_sensor", "cover"],
+    cameras: ["camera"], security: ["alarm_control_panel", "lock", "binary_sensor", "sensor"],
+    music: ["media_player"], energy: ["sensor", "number"], heating: ["climate", "sensor"],
+    car: ["device_tracker", "sensor", "binary_sensor"], pool: ["sensor", "switch", "light"],
+    waste: ["calendar", "sensor"], weather: ["weather", "sensor"]
+  };
+
+  function escape(value) { const el = document.createElement("span"); el.textContent = String(value ?? ""); return el.innerHTML; }
+  function cardsPath(section) { return `pageLayouts.${section}.cards`; }
+  function entitiesFor(section) {
+    const hints = DOMAIN_HINTS[section] || [];
+    return BeastCardEditor.allEntities().filter((entity) => {
+      const domain = entity.id.split(".")[0];
+      return !hints.length || hints.includes(domain) || entity.name.toLowerCase().includes(section);
+    });
+  }
+  function cardMarkup(card) {
+    const size = `data-builder-card="${escape(card.id)}" style="--desktop-w:${Number(card.desktop?.w) || 3};--desktop-h:${Number(card.desktop?.h) || 1};--tablet-w:${Number(card.tablet?.w) || 1};--tablet-h:${Number(card.tablet?.h) || 1};--portrait-h:${Number(card.portrait?.h) || 1};"`;
+    const standard = ["stat", "toggle", "graph", "camera", "media", "calendar"].includes(card.type) ? card.type : "custom";
+    const host = standard === "custom" ? "<div class=\"beastOvGeneric\"></div>" : "<div class=\"beastStandardCardBody\"></div>";
+    return `<section class="beast-panel beast-ov-card beast-page-builder-card beast-page-entity-card${card.enabled === false ? " is-disabled" : ""}" ${size} data-standard-card="${standard}" data-entity="${escape(card.entity || "")}" data-label="${escape(card.label || "")}" data-icon="${escape(card.icon || "grid")}">${host}<small class="beast-page-card-label">${escape(card.label || "")}</small></section>`;
+  }
+  function seed(section) {
+    // Do not populate a page implicitly when edit mode opens. The user
+    // should decide which cards belong on a view; relevant entities are
+    // offered as suggestions in the add/configure dialog instead.
+    return [];
+  }
+  function configureCard(card, commit, section) {
+    const overlay = document.createElement("div");
+    overlay.className = "beast-modal-overlay";
+    const entities = BeastCardEditor.allEntities();
+    overlay.innerHTML = `<div class="beast-modal beast-page-entity-modal" role="dialog" aria-modal="true"><div class="beast-modal-header"><h3>Indstil kort</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><label class="beast-page-editor-field">Korttype<select class="beast-page-card-type"><option value="custom">Entity / sensor</option><option value="stat">Statistik</option><option value="toggle">Touch-knap</option></select></label><label class="beast-page-editor-field">Navn på kort<input type="text" class="beast-page-card-name" placeholder="Valgfrit navn" value="${escape(card.label || "")}"></label><label class="beast-page-editor-field">Ikon<input type="text" class="beast-page-card-icon" placeholder="grid, bolt, light…" value="${escape(card.icon || "grid")}"></label><label class="beast-page-editor-check"><input type="checkbox" class="beast-page-card-enabled" ${card.enabled !== false ? "checked" : ""}> Vis kortet i normal visning</label><p class="beast-page-editor-hint">Forslag til ${escape(LABELS[section] || section)} vises først. Søgningen dækker alle Home Assistant-entiteter.</p><input type="search" class="beast-page-entity-search" placeholder="Søg i alle entities…" value="${escape(card.entity || "")}"><select class="beast-page-entity-select" size="8"></select><button type="button" class="beast-btn beast-btn-primary" data-save>Gem kort</button></div></div>`;
+    document.body.appendChild(overlay);
+    const search = overlay.querySelector(".beast-page-entity-search"), select = overlay.querySelector(".beast-page-entity-select");
+    const typeSelect = overlay.querySelector(".beast-page-card-type");
+    if (typeSelect) typeSelect.value = card.type || "custom";
+    const renderOptions = () => {
+      const query = search.value.trim().toLowerCase();
+      const suggested = entitiesFor(section);
+      const list = (query ? entities : suggested).filter((item) => !query || item.name.toLowerCase().includes(query) || item.id.toLowerCase().includes(query));
+      select.innerHTML = list.map((item) => `<option value="${escape(item.id)}">${escape(item.name)} · ${escape(item.id)}</option>`).join("");
+      if (card.entity) select.value = card.entity;
+    };
+    renderOptions();
+    search.addEventListener("input", renderOptions);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (event.target.closest("[data-save]") && select.value) { commit({ ...card, type: typeSelect?.value || "custom", entity: select.value, label: overlay.querySelector(".beast-page-card-name")?.value?.trim() || "", icon: overlay.querySelector(".beast-page-card-icon")?.value?.trim() || "grid", enabled: overlay.querySelector(".beast-page-card-enabled")?.checked !== false }); overlay.remove(); }
+    });
+    search.focus();
+  }
+  function mount(section, zone) {
+    if (!zone || EXCLUDED.has(section) || zone.dataset.pageEditorMounted === "true") return;
+    zone.dataset.pageEditorMounted = "true";
+    zone.classList.add("beast-page-editor-scroll-host");
+    const host = document.createElement("div");
+    host.className = "beast-page-editor-host";
+    host.innerHTML = `<button type="button" class="beast-page-edit-trigger" aria-label="Rediger ${escape(LABELS[section] || section)}" title="Rediger siden">⋮</button><div class="beast-overview-grid beast-page-builder-grid beast-page-entity-grid is-freeform"></div>`;
+    zone.appendChild(host);
+    const grid = host.querySelector(".beast-page-entity-grid");
+    const editor = BeastCardEditor.attach({
+      zoneEl: grid, configPath: cardsPath(section), cardTypes: [["stat", "Statistik"], ["toggle", "Touch-knap"], ["graph", "Graf"], ["camera", "Kamera"], ["media", "Medieafspiller"], ["calendar", "Kalender"], ["custom", "Entity / sensor"]],
+      renderCardMarkup: cardMarkup, seedCards: () => seed(section), defaultCardSize: { desktop: { w: 3, h: 1 }, tablet: { w: 1, h: 1 }, portrait: { h: 1 } },
+      allEntities: BeastCardEditor.allEntities, entityPickerTypes: ["stat", "toggle", "graph", "camera", "media", "calendar", "custom"], editLabel: `Redigerer ${LABELS[section] || section}`,
+      configureCard: (card, commit) => configureCard(card, commit, section), onAfterRender: () => BeastStandardCards.wire(grid)
+    });
+    host.querySelector(".beast-page-edit-trigger").addEventListener("click", () => editor.enter());
+    // Page modules may repaint their zone when HA state changes. Reattach the
+    // editor host after such a repaint without touching the page's own cards.
+    const observer = new MutationObserver(() => {
+      if (!zone.contains(host)) {
+        zone.dataset.pageEditorMounted = "";
+        observer.disconnect();
+        window.setTimeout(() => mount(section, zone), 0);
+      }
+    });
+    observer.observe(zone, { childList: true });
+  }
+  function mountAll() {
+    document.querySelectorAll(".beast-section[data-section]").forEach((section) => {
+      const id = section.dataset.section;
+      if (EXCLUDED.has(id)) return;
+      const zone = section.querySelector("[id$='Zone']") || section.firstElementChild;
+      if (zone) mount(id, zone);
+    });
+  }
+  return { mountAll };
+})();

--- a/js/ha-smartdash-page-layout.js
+++ b/js/ha-smartdash-page-layout.js
@@ -1,0 +1,25 @@
+// Shared contract for migrating existing specialised view widgets into the
+// live card editor. A widget keeps its page-specific renderer/wiring while
+// the layout layer owns id, visibility, label, position and size.
+window.BeastPageLayout = (() => {
+  const VERSION = 1;
+  function normalize(widget, fallback = {}) {
+    const source = widget && typeof widget === "object" ? widget : {};
+    return {
+      id: typeof source.id === "string" && source.id ? source.id : fallback.id || `widget_${Date.now()}`,
+      type: source.type || fallback.type || "special",
+      label: typeof source.label === "string" ? source.label : (fallback.label || ""),
+      enabled: source.enabled !== false,
+      desktop: { w: Math.max(1, Math.min(12, Number(source.desktop?.w) || Number(fallback.desktop?.w) || 4)), h: Math.max(1, Math.min(2, Number(source.desktop?.h) || Number(fallback.desktop?.h) || 1)) },
+      tablet: { w: Math.max(1, Math.min(2, Number(source.tablet?.w) || Number(fallback.tablet?.w) || 1)), h: Math.max(1, Math.min(2, Number(source.tablet?.h) || Number(fallback.tablet?.h) || 1)) },
+      portrait: { h: Math.max(1, Math.min(2, Number(source.portrait?.h) || Number(fallback.portrait?.h) || 1)) },
+      settings: source.settings && typeof source.settings === "object" ? source.settings : (fallback.settings || {})
+    };
+  }
+  function migrate(list, defaults = []) {
+    const current = Array.isArray(list) ? list : [];
+    const fallback = new Map((Array.isArray(defaults) ? defaults : []).map((item) => [item.id, item]));
+    return current.map((item) => normalize(item, fallback.get(item?.id))).concat((Array.isArray(defaults) ? defaults : []).filter((item) => !current.some((existing) => existing?.id === item.id)).map((item) => normalize(item)));
+  }
+  return { VERSION, normalize, migrate };
+})();

--- a/js/ha-smartdash-pool.js
+++ b/js/ha-smartdash-pool.js
@@ -121,7 +121,7 @@
     }
 
     containerEl.innerHTML = `
-      <div class="beast-pool-dashboard">
+      <button type="button" class="beast-page-edit-trigger" id="beastPoolLayoutEdit" aria-label="Rediger poollayout">⋮</button><div class="beast-pool-dashboard">
         <section class="beast-pool-hero">
           <header><span>${BeastCore.icon("droplet", { size: 22 })} Pool</span><em id="beastPoolHeaderStatus">${escapeHtml(status?.state || "Ukendt status")}</em></header>
           <div class="beast-pool-water-orb">
@@ -155,6 +155,7 @@
         </section>
       </div>
     `;
+    wirePoolLayout();
     renderTemperatureHistory();
 
     document.getElementById("beastPoolPumpBtn")?.addEventListener("click", () => {
@@ -164,6 +165,28 @@
     document.getElementById("beastPoolAutoBtn")?.addEventListener("click", () => {
       const button = document.getElementById("beastPoolAutoBtn");
       callService("input_boolean", button.dataset.on === "true" ? "turn_off" : "turn_on", IDS.automation);
+    });
+  }
+
+  function wirePoolLayout() {
+    const layout = BeastConfig.get("pageLayouts.pool.poolLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const selectors = { hero: ".beast-pool-hero", camera: ".beast-pool-live", insights: ".beast-pool-insights" };
+    Object.entries(selectors).forEach(([id, selector]) => containerEl.querySelectorAll(selector).forEach((el) => el.classList.toggle("is-layout-hidden", hidden.has(id))));
+    containerEl.querySelector("#beastPoolLayoutEdit")?.addEventListener("click", () => openPoolLayout(layout));
+  }
+
+  function openPoolLayout(layout) {
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const items = [["hero", "Poolstatus og styring"], ["camera", "Livekamera"], ["insights", "Temperatur og driftsindsigt"]];
+    const overlay = document.createElement("div"); overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal beast-pool-layout-modal"><div class="beast-modal-header"><h3>Rediger poollayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><div class="beast-pool-layout-list">${items.map(([id,label]) => `<label><input type="checkbox" data-pool-section="${id}" ${hidden.has(id) ? "" : "checked"}><strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-save-pool-layout>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (!event.target.closest("[data-save-pool-layout]")) return;
+      const nextHidden = items.filter(([id]) => !overlay.querySelector(`[data-pool-section="${id}"]`).checked).map(([id]) => id);
+      BeastConfig.set("pageLayouts.pool.poolLayout", { ...layout, hidden: nextHidden }); overlay.remove(); render();
     });
   }
 

--- a/js/ha-smartdash-rooms.js
+++ b/js/ha-smartdash-rooms.js
@@ -5,6 +5,7 @@
   const PRESENCE_CLASSES = ["motion", "occupancy", "presence"];
   let ROOM_CLIMATE_SENSORS = {};
   let ROOM_POPUP_ENTITIES = {};
+  let ROOM_LAYOUT = { order: [], hidden: [], sizes: {} };
 
   // No real photo on file for every area — these self-contained gradient
   // placeholders (no external image dependency) stand in where one is missing.
@@ -143,15 +144,22 @@
   // only the text/badges that actually change get touched, and a card's
   // photo is fetched once, on creation, never again.
   function renderGrid() {
+    const configured = BeastConfig.get("pageLayouts.rooms") || {};
+    ROOM_LAYOUT = configured.roomLayout || ROOM_LAYOUT;
+    const hidden = new Set(Array.isArray(ROOM_LAYOUT.hidden) ? ROOM_LAYOUT.hidden : []);
+    const order = Array.isArray(ROOM_LAYOUT.order) ? ROOM_LAYOUT.order : [];
+    const orderIndex = new Map(order.map((id, index) => [id, index]));
     const areas = ROOM_ORDER
       .map((areaId) => BeastRegistry.getArea(areaId))
-      .filter(Boolean);
+      .filter((area) => area && !hidden.has(area.area_id))
+      .sort((a, b) => (orderIndex.get(a.area_id) ?? 9999) - (orderIndex.get(b.area_id) ?? 9999));
 
     let grid = document.getElementById("beastRoomsGrid");
     if (!grid) {
-      containerEl.innerHTML = `<div class="beast-rooms-grid" id="beastRoomsGrid"></div><div id="beastRoomModalHost"></div>`;
+      containerEl.innerHTML = `<button type="button" class="beast-page-edit-trigger beast-rooms-layout-trigger" id="beastRoomsLayoutEdit" aria-label="Rediger rumkort" title="Rediger rumkort">⋮</button><div class="beast-rooms-grid" id="beastRoomsGrid"></div><div id="beastRoomModalHost"></div>`;
       grid = document.getElementById("beastRoomsGrid");
       observeGridResize(grid);
+      document.getElementById("beastRoomsLayoutEdit")?.addEventListener("click", openRoomLayoutEditor);
     }
 
     areas.forEach((area) => {
@@ -184,6 +192,11 @@
       card.type = "button";
       card.className = "beast-room-card";
       card.dataset.areaId = area.area_id;
+      const size = ROOM_LAYOUT.sizes?.[area.area_id];
+      if (size?.w || size?.h) {
+        card.style.setProperty("--room-card-w", String(Math.max(1, Math.min(4, Number(size.w) || 1))));
+        card.style.setProperty("--room-card-h", String(Math.max(1, Math.min(2, Number(size.h) || 1))));
+      }
       card.innerHTML = `
         <div class="beast-room-photo">${roomPhotoMarkup(area)}</div>
         <div class="beast-room-climate" aria-label="Temperatur ${summary.temperatureLabel}, fugtighed ${summary.humidityLabel}">
@@ -201,6 +214,31 @@
       if (img) BeastAuth.setAuthedImageSrc(img, img.dataset.haPath);
     });
     balanceGridColumns(grid);
+  }
+
+  function openRoomLayoutEditor() {
+    document.getElementById("beastRoomLayoutEditor")?.remove();
+    const layout = BeastConfig.get("pageLayouts.rooms.roomLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const order = Array.isArray(layout.order) && layout.order.length ? layout.order.slice() : ROOM_ORDER.slice();
+    const ids = [...new Set([...order, ...ROOM_ORDER])].filter((id) => ROOM_ORDER.includes(id));
+    const overlay = document.createElement("div"); overlay.id = "beastRoomLayoutEditor"; overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal beast-room-layout-modal" role="dialog" aria-modal="true"><div class="beast-modal-header"><h3>Rediger rumkort</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><p class="beast-page-editor-hint">Skjul rum eller ændr rækkefølgen. Popup-styringen i hvert rum ændres ikke.</p><div class="beast-room-layout-list">${ids.map((id, index) => { const area = BeastRegistry.getArea(id); return `<div class="beast-room-layout-row" data-room-layout-id="${id}"><label><input type="checkbox" data-room-visible ${hidden.has(id) ? "" : "checked"}> <strong>${area?.name || id}</strong></label><div><button type="button" data-room-up ${index ? "" : "disabled"}>↑</button><button type="button" data-room-down ${index < ids.length - 1 ? "" : "disabled"}>↓</button></div></div>`; }).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-room-layout-save>Gem rumlayout</button></div></div>`;
+    document.body.appendChild(overlay);
+    const list = overlay.querySelector(".beast-room-layout-list");
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (event.target.closest("[data-room-layout-save]")) {
+        const nextOrder = [...list.querySelectorAll("[data-room-layout-id]")].map((item) => item.dataset.roomLayoutId);
+        const nextHidden = [...list.querySelectorAll("[data-room-layout-id]")].filter((item) => !item.querySelector("[data-room-visible]").checked).map((item) => item.dataset.roomLayoutId);
+        BeastConfig.set("pageLayouts.rooms.roomLayout", { ...layout, order: nextOrder, hidden: nextHidden });
+        overlay.remove(); renderGrid(); return;
+      }
+      const row = event.target.closest("[data-room-layout-id]"); if (!row) return;
+      if (event.target.closest("[data-room-up]") && row.previousElementSibling) list.insertBefore(row, row.previousElementSibling);
+      if (event.target.closest("[data-room-down]") && row.nextElementSibling) list.insertBefore(row.nextElementSibling, row);
+      if (event.target.closest("[data-room-up], [data-room-down]")) overlay.querySelectorAll(".beast-room-layout-row").forEach((item, i, all) => { item.querySelector("[data-room-up]").disabled = i === 0; item.querySelector("[data-room-down]").disabled = i === all.length - 1; });
+    });
   }
 
   const GRID_MIN_CARD_WIDTH = 280;

--- a/js/ha-smartdash-security.js
+++ b/js/ha-smartdash-security.js
@@ -141,7 +141,7 @@
     const headline = alarmTriggered ? "Alarm aktiveret" : alarmArmed && !openSensors.length ? "Huset er sikret" : openSensors.length || unlockedCount ? "Kræver opmærksomhed" : "Klar til tilkobling";
     const subline = alarmTriggered ? "Kontrollér huset med det samme" : `${openSensors.length} åbne døre eller vinduer · ${unlockedCount} ulåste · ${onlineSystems}/${ALARM_PANELS.length} systemer online`;
     containerEl.innerHTML = `
-      <div class="beast-security-command${alarmTriggered ? " is-triggered" : ""}">
+      <button type="button" class="beast-page-edit-trigger" id="beastSecurityLayoutEdit" aria-label="Rediger sikkerhedslayout">⋮</button><div class="beast-security-command${alarmTriggered ? " is-triggered" : ""}">
         <section class="beast-security-hero">
           <div class="beast-security-hero-top">
             <span class="beast-security-orbit">${BeastCore.icon("shield", { size: 42 })}</span>
@@ -186,6 +186,13 @@
         </section>
       </div>
     `;
+    const securityLayout = BeastConfig.get("pageLayouts.security.securityLayout") || {};
+    const hiddenSections = new Set(Array.isArray(securityLayout.hidden) ? securityLayout.hidden : []);
+    ["hero", "systems", "entries"].forEach((name) => {
+      const element = containerEl.querySelector(`.beast-security-${name}`);
+      if (element) element.classList.toggle("is-layout-hidden", hiddenSections.has(name));
+    });
+    containerEl.querySelector("#beastSecurityLayoutEdit")?.addEventListener("click", openSecurityLayoutEditor);
 
     containerEl.querySelectorAll("[data-action='toggle-lock']").forEach((btn) => {
       btn.addEventListener("click", () => {
@@ -200,6 +207,23 @@
     containerEl.querySelector("[data-action='lock-all']")?.addEventListener("click", () => {
       const targets = entryStates.filter((entry) => !entry.locked).map((entry) => entry.lockEntity);
       if (targets.length) callService("lock", "lock", targets).then(() => window.setTimeout(render, 400));
+    });
+  }
+
+  function openSecurityLayoutEditor() {
+    document.getElementById("beastSecurityLayoutEditor")?.remove();
+    const current = BeastConfig.get("pageLayouts.security.securityLayout") || {};
+    const hidden = new Set(Array.isArray(current.hidden) ? current.hidden : []);
+    const items = [["hero", "Samlet sikkerhedsstatus"], ["systems", "Alarmsystemer"], ["entries", "Indgange, låse og åbninger"]];
+    const overlay = document.createElement("div"); overlay.id = "beastSecurityLayoutEditor"; overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal beast-security-layout-modal" role="dialog" aria-modal="true"><div class="beast-modal-header"><h3>Rediger sikkerhedslayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><p class="beast-page-editor-hint">Skjul de sektioner, du ikke vil bruge. Alarm- og låsestyring ændres ikke.</p><div class="beast-security-layout-list">${items.map(([id, label]) => `<label><input type="checkbox" data-security-section="${id}" ${hidden.has(id) ? "" : "checked"}> <strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-security-layout-save>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (!event.target.closest("[data-security-layout-save]")) return;
+      const nextHidden = items.filter(([id]) => !overlay.querySelector(`[data-security-section="${id}"]`).checked).map(([id]) => id);
+      BeastConfig.set("pageLayouts.security.securityLayout", { ...current, hidden: nextHidden });
+      overlay.remove(); render();
     });
   }
 

--- a/js/ha-smartdash-standard-cards.js
+++ b/js/ha-smartdash-standard-cards.js
@@ -14,6 +14,11 @@
 window.BeastStandardCards = (function () {
   const TYPES = [
     ["stat", "Statistik"],
+    ["toggle", "Touch-knap"],
+    ["graph", "Graf"],
+    ["camera", "Kamera"],
+    ["media", "Medieafspiller"],
+    ["calendar", "Kalender"],
     ["custom", "Valgfri HA-entity"],
   ];
   const ENTITY_PICKER_TYPES = TYPES.map(([value]) => value);
@@ -37,6 +42,10 @@ window.BeastStandardCards = (function () {
     if (card.type === "stat") {
       return `<div class="beast-panel beast-panel-fill beast-ov-card beast-ov-card--stat"${size} data-standard-card="stat" data-entity="${escape(card.entity)}"><div class="beastStandardCardBody"></div></div>`;
     }
+    if (card.type === "toggle") {
+      return `<section class="beast-panel beast-ov-card beast-ov-card--generic beast-standard-toggle-card"${size} data-standard-card="toggle" data-entity="${escape(card.entity)}"><div class="beastStandardCardBody"></div></section>`;
+    }
+    if (["graph", "camera", "media", "calendar"].includes(card.type)) return `<section class="beast-panel beast-ov-card beast-standard-${escape(card.type)}-card"${size} data-standard-card="${escape(card.type)}" data-entity="${escape(card.entity)}"><div class="beastStandardCardBody"></div></section>`;
     return `<section class="beast-panel beast-ov-card beast-ov-card--generic"${size} data-standard-card="custom" data-entity="${escape(card.entity)}"><div class="beastOvGeneric"></div></section>`;
   }
 
@@ -46,17 +55,38 @@ window.BeastStandardCards = (function () {
   // generic widgets on every render.
   function wire(zoneEl) {
     if (!zoneEl) return;
-    zoneEl.querySelectorAll('[data-standard-card="stat"] .beastStandardCardBody, [data-standard-card="custom"] .beastOvGeneric').forEach((host) => {
+    zoneEl.querySelectorAll('[data-standard-card="stat"] .beastStandardCardBody, [data-standard-card="toggle"] .beastStandardCardBody, [data-standard-card="graph"] .beastStandardCardBody, [data-standard-card="camera"] .beastStandardCardBody, [data-standard-card="media"] .beastStandardCardBody, [data-standard-card="calendar"] .beastStandardCardBody, [data-standard-card="custom"] .beastOvGeneric').forEach((host) => {
       const card = host.closest("[data-standard-card]");
       const entityId = card.dataset.entity;
       const state = entityId ? BeastHaSocket.getState(entityId) : null;
       const unavailable = !state || ["unknown", "unavailable"].includes(state.state);
-      const label = state?.attributes?.friendly_name || entityId || "Ikke valgt";
+      const label = card.dataset.label || state?.attributes?.friendly_name || entityId || "Ikke valgt";
       const value = unavailable ? "Ikke tilgængelig" : state.state;
+      const icon = card.dataset.icon || "grid";
       if (card.dataset.standardCard === "stat") {
-        host.innerHTML = BeastCore.statTile({ icon: "grid", label, value, meta: unavailable ? "" : (state.attributes?.unit_of_measurement || "") });
+        host.innerHTML = BeastCore.statTile({ icon, label, value, meta: unavailable ? "" : (state.attributes?.unit_of_measurement || "") });
+      } else if (card.dataset.standardCard === "toggle") {
+        const domain = entityId?.split(".")[0] || "switch";
+        const active = state?.state === "on" || state?.state === "open" || state?.state === "unlocked";
+        host.innerHTML = `<button type="button" class="beast-standard-toggle" data-entity="${escape(entityId || "")}" data-domain="${escape(domain)}" data-active="${active}"><span class="beast-standard-toggle-icon">${BeastCore.icon(active ? "check" : "bolt", { size: 23 })}</span><span><small>${escape(label)}</small><strong>${active ? "Tændt" : "Slukket"}</strong></span></button>`;
+        host.querySelector("button")?.addEventListener("click", () => {
+          if (!entityId || unavailable) return;
+          const service = domain === "lock" ? (active ? "unlock" : "lock") : domain === "cover" ? (active ? "close_cover" : "open_cover") : (active ? "turn_off" : "turn_on");
+          BeastAuth.haFetch(`/api/services/${domain}/${service}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ entity_id: entityId }) }).catch((error) => BeastCore.log(`Kortstyring fejlede: ${error.message}`));
+        });
+      } else if (card.dataset.standardCard === "graph") {
+        const n = Number(state?.state); const points = Array.from({ length: 18 }, (_, i) => Number.isFinite(n) ? Math.max(0, n * (0.84 + ((i * 13) % 17) / 100)) : 0);
+        host.innerHTML = `<div class="beast-standard-graph"><small>${escape(label)}</small><strong>${escape(value)} ${escape(state?.attributes?.unit_of_measurement || "")}</strong>${BeastCore.sparkline(points, { color: "var(--accent)", height: 72 })}</div>`;
+      } else if (card.dataset.standardCard === "camera") {
+        const path = state?.attributes?.entity_picture || "";
+        host.innerHTML = `<div class="beast-standard-camera"><div class="beast-standard-camera-frame">${path ? `<img data-ha-path="${escape(path)}" alt="${escape(label)}">` : BeastCore.icon("camera", { size: 34 })}</div><strong>${escape(label)}</strong></div>`;
+        const image = host.querySelector("img[data-ha-path]"); if (image) BeastAuth.setAuthedImageSrc(image, image.dataset.haPath);
+      } else if (card.dataset.standardCard === "media") {
+        host.innerHTML = `<div class="beast-standard-media"><span>${BeastCore.icon("music", { size: 30 })}</span><div><small>${escape(label)}</small><strong>${escape(state?.attributes?.media_title || value)}</strong><em>${escape(state?.attributes?.media_artist || "")}</em></div></div>`;
+      } else if (card.dataset.standardCard === "calendar") {
+        host.innerHTML = `<div class="beast-standard-calendar"><span>${BeastCore.icon("calendar", { size: 28 })}</span><div><small>${escape(label)}</small><strong>${escape(state?.attributes?.message || value)}</strong><em>${escape(state?.attributes?.start_time || "Ingen tidspunkt")}</em></div></div>`;
       } else {
-        host.innerHTML = `<div class="beast-ov-generic-content"><span>${BeastCore.icon("grid", { size: 31 })}</span><small>${escape(label)}</small><strong>${escape(value)}</strong><em>${escape(entityId || "")}</em></div>`;
+        host.innerHTML = `<div class="beast-ov-generic-content"><span>${BeastCore.icon(icon, { size: 31 })}</span><small>${escape(label)}</small><strong>${escape(value)}</strong><em>${escape(entityId || "")}</em></div>`;
       }
       card.classList.toggle("is-unavailable", unavailable);
     });

--- a/js/ha-smartdash-waste.js
+++ b/js/ha-smartdash-waste.js
@@ -77,17 +77,40 @@
   function render() {
     if (!containerEl) return;
     containerEl.innerHTML = `
-      <section class="beast-waste-section">
+      <button type="button" class="beast-page-edit-trigger" id="beastCalendarLayoutEdit" aria-label="Rediger kalenderlayout">⋮</button>
+      <section class="beast-waste-section" data-calendar-section="waste">
         <p class="beast-panel-title">Affaldskalender</p>
         <div class="beast-stat-grid">${buildWasteMarkup()}</div>
       </section>
-      <section class="beast-waste-section">
+      <section class="beast-waste-section" data-calendar-section="events">
         <p class="beast-panel-title">Kommende begivenheder</p>
         <div class="beast-stat-grid" id="beastCalendarEvents"><p class="beast-music-empty">Henter…</p></div>
       </section>
     `;
+    wireCalendarLayout();
 
     loadCalendarEvents().then(renderCalendarEvents);
+  }
+
+  function wireCalendarLayout() {
+    const layout = BeastConfig.get("pageLayouts.waste.calendarLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    containerEl.querySelectorAll("[data-calendar-section]").forEach((el) => el.classList.toggle("is-layout-hidden", hidden.has(el.dataset.calendarSection)));
+    containerEl.querySelector("#beastCalendarLayoutEdit")?.addEventListener("click", () => openCalendarLayout(layout));
+  }
+
+  function openCalendarLayout(layout) {
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const items = [["waste", "Affald og afhentning"], ["events", "Kommende kalenderaftaler"]];
+    const overlay = document.createElement("div"); overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal beast-calendar-layout-modal"><div class="beast-modal-header"><h3>Rediger kalenderlayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><div class="beast-calendar-layout-list">${items.map(([id,label]) => `<label><input type="checkbox" data-calendar-layout-section="${id}" ${hidden.has(id) ? "" : "checked"}><strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-save-calendar-layout>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest("[data-close]")) return overlay.remove();
+      if (!event.target.closest("[data-save-calendar-layout]")) return;
+      const nextHidden = items.filter(([id]) => !overlay.querySelector(`[data-calendar-layout-section="${id}"]`).checked).map(([id]) => id);
+      BeastConfig.set("pageLayouts.waste.calendarLayout", { ...layout, hidden: nextHidden }); overlay.remove(); render();
+    });
   }
 
   function init(root) {

--- a/js/ha-smartdash-weather.js
+++ b/js/ha-smartdash-weather.js
@@ -98,7 +98,7 @@
   function render() {
     if (!rootEl) return;
     if (!rootEl.querySelector(".beast-weather-dashboard")) {
-      rootEl.innerHTML = `<div class="beast-weather-dashboard"><div class="beast-weather-left">${currentMarkup()}${hourlyMarkup()}</div>${radarMarkup()}${dailyMarkup()}</div>`;
+      rootEl.innerHTML = `<button type="button" class="beast-page-edit-trigger" id="beastWeatherLayoutEdit" aria-label="Rediger vejrlayout">⋮</button><div class="beast-weather-dashboard"><div class="beast-weather-left">${currentMarkup()}${hourlyMarkup()}</div>${radarMarkup()}${dailyMarkup()}</div>`;
       rootEl.querySelectorAll("[data-layer]").forEach((btn) => {
         btn.addEventListener("click", () => {
           if (btn.dataset.layer === radarLayer) return;
@@ -108,11 +108,31 @@
         });
       });
       drawRadar();
+      wireWeatherLayout();
       return;
     }
     rootEl.querySelector(".beast-weather-current").outerHTML = currentMarkup();
     rootEl.querySelector(".beast-weather-hourly").outerHTML = hourlyMarkup();
     rootEl.querySelector(".beast-weather-week").outerHTML = dailyMarkup();
+    wireWeatherLayout();
+  }
+
+  function wireWeatherLayout() {
+    const layout = BeastConfig.get("pageLayouts.weather.weatherLayout") || {};
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const selectors = { current: ".beast-weather-current", hourly: ".beast-weather-hourly", week: ".beast-weather-week", radar: ".beast-weather-radar" };
+    Object.entries(selectors).forEach(([id, selector]) => rootEl.querySelector(selector)?.classList.toggle("is-layout-hidden", hidden.has(id)));
+    const button = rootEl.querySelector("#beastWeatherLayoutEdit");
+    if (button && !button.dataset.wired) { button.dataset.wired = "true"; button.addEventListener("click", () => openWeatherLayout(layout)); }
+  }
+
+  function openWeatherLayout(layout) {
+    const hidden = new Set(Array.isArray(layout.hidden) ? layout.hidden : []);
+    const items = [["current","Aktuelt vejr"],["hourly","Timeudsigt"],["week","Ugeudsigt"],["radar","Radar"]];
+    const overlay = document.createElement("div"); overlay.className = "beast-modal-overlay";
+    overlay.innerHTML = `<div class="beast-modal"><div class="beast-modal-header"><h3>Rediger vejrlayout</h3><button type="button" class="beast-modal-close" data-close>×</button></div><div class="beast-modal-body"><div class="beast-weather-layout-list">${items.map(([id,label]) => `<label><input type="checkbox" data-weather-section="${id}" ${hidden.has(id)?"":"checked"}><strong>${label}</strong></label>`).join("")}</div><button type="button" class="beast-btn beast-btn-primary" data-save-weather-layout>Gem layout</button></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => { if (event.target===overlay || event.target.closest("[data-close]")) return overlay.remove(); if (!event.target.closest("[data-save-weather-layout]")) return; const nextHidden=items.filter(([id])=>!overlay.querySelector(`[data-weather-section="${id}"]`).checked).map(([id])=>id); BeastConfig.set("pageLayouts.weather.weatherLayout", {...layout,hidden:nextHidden}); overlay.remove(); wireWeatherLayout(); });
   }
 
   function updateRadarTabs() {


### PR DESCRIPTION
## Hvad er ændret
- tilføjer et fælles redigeringssystem til dashboardets øvrige sider
- gør eksisterende kort redigerbare og understøtter egne kort baseret på Home Assistant-enheder
- tilføjer layoutstyring til rum, sikkerhed, energi, varme, pool, bil, kalender, musik, vejr og kameraer
- sikrer lodret scrolling, når kortenes samlede højde overstiger skærmen
- forbedrer kameraets genforbindelse uden at genindlæse hele dashboardet
- retter den tomme rumside og fastholder redigeringsknapper, når sektioner skjules
- opdaterer changelog og versionsmetadata til v0.6.3 (build 20260809-71)

## Hvorfor
Dashboardet skal kunne udbygges direkte på touchskærmen uden afskårne kort, mistet scrollposition eller tvungne sidegenindlæsninger.

## Kontrol
- releasekontrol gennemført
- JSON/changelog valideret
- diff kontrolleret for formateringsfejl
- live-filer og afhængigheder kontrolleret
- ingen legitimationsoplysninger fundet i ændringerne